### PR TITLE
Add upgrade icon when tool is outdated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ dist: ## generate package artifacts
 
 .PHONY: docs
 docs:  ## generate documentation
-	$(MAKE) -s _docker_$@
+	$(MAKE) -s _$@
 
 .PHONY: deploy
 deploy: dist  ## deploy Python package to PyPI

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ $ mercado {command}
 ```
     """))
 
-print_command("list --names-only")
+print_command("list --names-only --all")
 
 ]]] -->
 
 ```bash
-$ mercado list --names-only
+$ mercado list --names-only --all
 
 Mercado tools 
 ┏━━━━━━━━━━━━┓
@@ -92,36 +92,62 @@ $ {command}
 ```
     """))
 
+print_command("mercado list --verbose")
+
 print_command("mercado install gh")
 
 print_command("mercado is-latest docker")
 
 print_command("mercado show minikube")
 
-print_command("mercado list --label k8s --with-labels")
-
-print_command("mercado list --installed-only --verbose")
+print_command("mercado list --label k8s --with-labels --all")
 
 ]]] -->
 
 ```bash
+$ mercado list --verbose
+
+                                       Mercado tools                                        
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Name       ┃ Vendor     ┃ Installed                                                      ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ compose    │ GitHub     │ ⏫ (/home/yuvalgold/.docker/cli-plugins/docker-compose 2.13.0) │
+│ gh         │ GitHub     │ ✅ (/home/yuvalgold/.mercado/gh 2.25.1)                        │
+│ kind       │ GitHub     │ ✅ (/home/yuvalgold/.mercado/kind 0.18.0)                      │
+│ minikube   │ GitHub     │ ✅ (/home/yuvalgold/.mercado/minikube 1.29.0)                  │
+│ terragrunt │ GitHub     │ ⏫ (/home/yuvalgold/.mercado/terragrunt 0.42.5)                │
+├────────────┼────────────┼────────────────────────────────────────────────────────────────┤
+│ consul     │ Hashicorp  │ ⏫ (/usr/local/bin/consul 1.13.1)                              │
+│ terraform  │ Hashicorp  │ ✅ (/home/yuvalgold/.mercado/terraform 1.4.4)                  │
+│ vagrant    │ Hashicorp  │ ⏫ (/home/yuvalgold/.mercado/vagrant 2.3.2)                    │
+│ vault      │ Hashicorp  │ ✅ (/home/yuvalgold/.mercado/vault 1.13.1)                     │
+├────────────┼────────────┼────────────────────────────────────────────────────────────────┤
+│ kubectl    │ URLFetcher │ ⏫ (/home/yuvalgold/.mercado/kubectl 1.25.3)                   │
+├────────────┼────────────┼────────────────────────────────────────────────────────────────┤
+│ docker     │ Shell      │ ⏫ (/usr/bin/docker 23.0.1)                                    │
+│ helm       │ Shell      │ ⏫ (/home/yuvalgold/.mercado/helm 3.11.0)                      │
+└────────────┴────────────┴────────────────────────────────────────────────────────────────┘
+```
+
+
+```bash
 $ mercado install gh
 
-[12/10/22 04:16:21] Looking for the latest version of 'gh'                                                                                                       
-[12/10/22 04:16:22] Getting installer for tool 'gh' with version v2.20.2 for linux and x86_64                                                                    
-                    Installing 'gh'...                                                                                                                           
-[12/10/22 04:16:23] Downloading 'gh' to /tmp/gh_2.20.2_linux_amd64.tar.gz (size: 9.6 MB)                                                                         
+[03/31/23 17:18:48] Looking for the latest version of 'gh'                                                                                                                                                 
+[03/31/23 17:18:49] Getting installer for tool 'gh' with version v2.25.1 for linux and x86_64                                                                                                              
+                    Installing 'gh'...                                                                                                                                                                     
+[03/31/23 17:18:50] Downloading 'gh' to /tmp/gh_2.25.1_linux_amd64.tar.gz (size: 10.1 MB)                                                                                                                  
 Downloading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-[12/10/22 04:16:27] Unpacking /tmp/gh_2.20.2_linux_amd64.tar.gz to /tmp/gh_2.20.2_linux_amd64.tar                                                                
-                    Copying /tmp/gh_2.20.2_linux_amd64.tar/gh_2.20.2_linux_amd64/bin/gh to /home/yuvalgold/.mercado/gh                                           
-👍       'gh' version v2.20.2 is installed
+[03/31/23 17:18:51] Unpacking /tmp/gh_2.25.1_linux_amd64.tar.gz to /tmp/gh_2.25.1_linux_amd64.tar                                                                                                          
+                    Copying /tmp/gh_2.25.1_linux_amd64.tar/gh_2.25.1_linux_amd64/bin/gh to /home/yuvalgold/.mercado/gh                                                                                     
+👍       'gh' version v2.25.1 is installed
 ```
 
 
 ```bash
 $ mercado is-latest docker
 
-👍       You have the latest version of 'docker' (20.10.21)
+👎       'docker' version 'v23.0.2' is available! (current: 23.0.1)
 ```
 
 
@@ -129,50 +155,26 @@ $ mercado is-latest docker
 $ mercado show minikube
 
 Name: minikube
-Installed: ✅
-Local Version: 1.27.1
+Status: ✅
+Local Version: 1.29.0
 Path: /home/yuvalgold/.mercado/minikube
-Remote Version: v1.28.0
+Remote Version: v1.29.0
 ```
 
 
 ```bash
-$ mercado list --label k8s --with-labels
+$ mercado list --label k8s --with-labels --all
 
                    Mercado tools                   
 ┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
 ┃ Name     ┃ Labels                   ┃ Installed ┃
 ┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
-│ helm     │ k8s                      │ ❌        │
+│ helm     │ k8s                      │ ⏫        │
 │ k3d      │ k8s,docker,orchestration │ ❌        │
 │ kind     │ k8s,docker,orchestration │ ✅        │
-│ kubectl  │ k8s                      │ ✅        │
+│ kubectl  │ k8s                      │ ⏫        │
 │ minikube │ k8s,orchestration        │ ✅        │
 └──────────┴──────────────────────────┴───────────┘
-```
-
-
-```bash
-$ mercado list --installed-only --verbose
-
-                                       Mercado tools                                       
-┏━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Name      ┃ Vendor     ┃ Installed                                                      ┃
-┡━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ compose   │ GitHub     │ ✅ (/home/yuvalgold/.docker/cli-plugins/docker-compose 2.13.0) │
-│ gh        │ GitHub     │ ✅ (/home/yuvalgold/.mercado/gh 2.20.2)                        │
-│ kind      │ GitHub     │ ✅ (/home/yuvalgold/.mercado/kind 0.17.0)                      │
-│ minikube  │ GitHub     │ ✅ (/home/yuvalgold/.mercado/minikube 1.27.1)                  │
-├───────────┼────────────┼────────────────────────────────────────────────────────────────┤
-│ consul    │ Hashicorp  │ ✅ (/usr/local/bin/consul 1.13.1)                              │
-│ terraform │ Hashicorp  │ ✅ (/home/yuvalgold/.mercado/terraform 1.3.3)                  │
-│ vagrant   │ Hashicorp  │ ✅ (/home/yuvalgold/.mercado/vagrant 2.3.2)                    │
-│ vault     │ Hashicorp  │ ✅ (/home/yuvalgold/.mercado/vault 1.12.1)                     │
-├───────────┼────────────┼────────────────────────────────────────────────────────────────┤
-│ kubectl   │ URLFetcher │ ✅ (/home/yuvalgold/.mercado/kubectl 1.25.3)                   │
-├───────────┼────────────┼────────────────────────────────────────────────────────────────┤
-│ docker    │ Shell      │ ✅ (/usr/bin/docker 20.10.21)                                  │
-└───────────┴────────────┴────────────────────────────────────────────────────────────────┘
 ```
 
 <!-- [[[end]]] -->

--- a/mercado/tool_manager.py
+++ b/mercado/tool_manager.py
@@ -1,6 +1,8 @@
 import logging
+from pathlib import Path
 
 from .tools import TOOLS
+from .utils import get_local_version, is_tool_available
 from .vendors.vendor import Installer, Tool, ToolVendor
 
 
@@ -50,6 +52,18 @@ class ToolManager:
 
         logging.info(f"Getting installer for tool '{tool.name}' with version {version} for {os} and {arch}")
         return vendor.get_installer(tool, version, os, arch)
+
+    def get_status(self, name: str) -> tuple[bool, bool, str, Path | None, str]:
+        tool = self.get_tool(name)
+        exists = is_tool_available(tool)
+        local_version = ''
+        path = None
+        latest_version = ''
+
+        if exists:
+            local_version, path = get_local_version(self.get_tool(name))
+            latest_version = self.get_latest_version(name)
+        return exists, local_version in latest_version, local_version, path, latest_version
 
 
 manager = ToolManager()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mercado"
-version = "0.1.4"
+version = "0.1.5"
 description = "All-In-One Development CLI Tools Multi-platform Marketplace"
 
 authors = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 import pytest
-from mercado.cli import install_tool, is_latest
+from mercado.cli import install_tool, get_status
 from mercado.tool_manager import ToolManager
 
 
@@ -13,4 +13,4 @@ def test_download_invalid_version(vendor: str, tool: str, os: str, arch: str):
 @pytest.mark.parametrize("tool", [t.name for _, tools in ToolManager().get_supported_tools() for t in tools])
 def test_download_and_verify_latest(tool: str, os: str, arch: str):
     install_tool(names=[tool], os=os, arch=arch, dry_run=False)
-    is_latest(tool)
+    get_status(tool)


### PR DESCRIPTION
- List installed only by default, and replace "--installed-only" flag
  with an "--all" flag.
- Add upgrade icon, now `show` and `list` commands print whether a tool
  is outdated.
- Improve table look with header `bold magneta` and the name column as
  bold.
- Add exit status 1 when tool can't be found, and when `is-latest`
  command is false.
