### PR TITLE
Run CI tests on macos-latest

### DIFF
--- a/.github/workflows/github-action-test.yaml
+++ b/.github/workflows/github-action-test.yaml
@@ -7,18 +7,59 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+env:
+  LOGLEVEL: DEBUG
+
+  # Supporting AppImage artifacts
+  # https://github.com/AppImage/AppImageKit/issues/912#issuecomment-528669441
+  APPIMAGE_EXTRACT_AND_RUN: 1
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2'
       - run: make lint
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - run: make test
+      # Installing python directly due to poetry issue with upstream python
+      # https://github.com/python-poetry/poetry/issues/7343
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.4.2
+          virtualenvs-create: false
+      - name: Install dependencies
+        run: |
+          make deps
+          echo "$HOME/.mercado" >> $GITHUB_PATH
+      # Allow debugging with tmate
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
+      - name: Run tests
+        run: make _test
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -11,12 +11,10 @@ ENV \
   PIP_DEFAULT_TIMEOUT=100 \
   PATH="${PATH}:${HOME}/root/.mercado"
 
-RUN pip install "poetry==1.2.2"
-
 WORKDIR /app
-COPY poetry.lock pyproject.toml /app/
+COPY Makefile poetry.lock pyproject.toml /app/
+COPY hack/deps.sh /app/hack/deps.sh
 
-RUN poetry config virtualenvs.create false \
-  && poetry install --no-interaction --no-ansi
+RUN make deps
 
 COPY . /app

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ deploy: dist  ## deploy Python package to PyPI
 
 ##@ general
 
+.PHONY: deps
+deps:  ## install dependencies
+	$(MAKE) -s _$@	
+
 .PHONY: clean
 clean:  ## clean environment
 	-$(MAKE) -s _$@

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Mercado tools
 ## Install
 
 ```bash
-python -m pip install mercado
+python3 -m pip install mercado
 ```
 
 ## How to use
@@ -261,10 +261,21 @@ mercado --help
 ### Run GHA
 
 I use [nektos/act](https://github.com/nektos/act) tool to run the Git Hub Action locally.
-By default, act runs on a slim container image, for docker-compose usage the base image is replaced.
 
 ```bash
-act --platform=ubuntu-latest=lucasalt/act_base:latest -j <JOB>
+act -j <JOB>
+```
+
+In order to run a specific test, set the appropriate OS and environment variable
+
+```bash
+act -j test --env TEST_FUNC=k3d --matrix os:ubuntu-latest
+```
+
+When local execution does not help, we can enable a remote debug with [tmate](https://github.com/marketplace/actions/debugging-with-tmate)
+
+```bash
+gh workflow run Test --ref <branch_name> -f debug_enabled=true
 ```
 
 ## Generate docs

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -5,5 +5,5 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-# python -m twine upload --verbose dist/*
+# python3 -m twine upload --verbose dist/*
 poetry publish

--- a/hack/deps.sh
+++ b/hack/deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o xtrace
+
+if [ ! -x "$(command -v poetry)" ]; then
+    python3 -m pip install "poetry==1.4.2"
+    poetry config virtualenvs.create false
+fi
+
+poetry install --verbose --no-interaction --no-ansi

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -5,4 +5,4 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-python -m pip install --verbose --force-reinstall ./dist/mercado-*.whl
+python3 -m pip install --verbose --force-reinstall ./dist/mercado-*.whl

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -5,6 +5,6 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-python -m flake8 --max-line-length 120 mercado tests
+python3 -m flake8 --max-line-length 120 mercado tests
 find . -name '*.sh' -type f -not -path "./.git/*" -exec shellcheck {} +
 git diff --shortstat --exit-code

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -5,4 +5,4 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-python -m pytest --log-cli-level="${LOGLEVEL:-info}" -s --verbose "${TEST:-tests}" -k "${TEST_FUNC:-}"
+python3 -m pytest --log-cli-level="${LOGLEVEL:-info}" -s --verbose "${TEST:-tests}" -k "${TEST_FUNC:-}"

--- a/mercado/utils.py
+++ b/mercado/utils.py
@@ -21,6 +21,7 @@ from urllib3 import Retry
 from .vendors.vendor import Tool
 
 MATRIX_X86_64 = ('amd64', 'x86_64', '64bit')
+MARRIX_MAC = ('darwin', 'macos')
 INSTALL_DIR = Path.home() / ".mercado"
 CHUNK_SIZE = 1024
 REQUEST_MAX_TIMEOUT = 10
@@ -35,12 +36,29 @@ def get_architecture_variations(arch: str) -> list[str]:
     return [arch]
 
 
+def get_operating_system_variations(os: str) -> list[str]:
+    if os in MARRIX_MAC:
+        return MARRIX_MAC
+    return [os]
+
+
 def is_valid_architecture(expected: str, actual: str) -> bool:
     '''
     Equalize architectures that their name does not necessarily match
     '''
-    for arch in get_architecture_variations(expected):
-        if re.search(arch, actual, re.IGNORECASE):
+    return contains_ignore_case(actual, get_architecture_variations(expected))
+
+
+def is_valid_os(expected: str, actual: str) -> bool:
+    '''
+    Equalize operating system that their name does not necessarily match
+    '''
+    return contains_ignore_case(actual, get_operating_system_variations(expected))
+
+
+def contains_ignore_case(item: str, lst: list[str]):
+    for element in lst:
+        if re.search(element, item, re.IGNORECASE):
             return True
 
     return False

--- a/mercado/vendors/hashicorp.py
+++ b/mercado/vendors/hashicorp.py
@@ -1,7 +1,9 @@
+import logging
 from functools import cache
 from http import HTTPStatus
 
-from ..utils import choose_url, create_session, is_valid_architecture
+from ..utils import (choose_url, create_session, is_valid_architecture,
+                     is_valid_os)
 from .url_fetcher import URLDownloader
 from .vendor import Installer, Tool, ToolVendor
 
@@ -38,9 +40,11 @@ class Hashicorp(ToolVendor):
         valid_assets_urls = []
 
         for item in builds:
-            if os == item['os'] and is_valid_architecture(expected=arch, actual=item['arch']):
+            if is_valid_os(expected=os, actual=item['os']) and \
+               is_valid_architecture(expected=arch, actual=item['arch']):
                 valid_assets_urls.append(item['url'])
 
+        logging.debug(f"Looking for the best url from: {valid_assets_urls}")
         return choose_url(valid_assets_urls)
 
     @cache
@@ -54,4 +58,5 @@ class Hashicorp(ToolVendor):
         if not url:
             raise ValueError(f'There is no available build {tool.name} for {os=}, {arch=}, {version=}')
 
+        logging.debug(f'Found {tool.name} with version {version} on URL {url}')
         return URLDownloader(tool.name, version, url, tool.target)

--- a/mercado/vendors/url_fetcher.py
+++ b/mercado/vendors/url_fetcher.py
@@ -2,11 +2,12 @@
 import logging
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Callable
 from pathlib import Path
+from typing import Callable
 
-from ..utils import (create_session, download_url, fetch_url,
-                     get_architecture_variations, default_install_path)
+from ..utils import (create_session, default_install_path, download_url,
+                     fetch_url, get_architecture_variations,
+                     get_operating_system_variations)
 from .vendor import Installer, Tool, ToolVendor
 
 
@@ -21,7 +22,8 @@ class URLFetcher(ToolVendor):
                     url_template: Callable[[str, str], str]) -> str:
         urls = []
         for arch in get_architecture_variations(arch):
-            urls.append(url_template(os, arch, version))
+            for os in get_operating_system_variations(os):
+                urls.append(url_template(os, arch, version))
 
         logging.debug(f"Tool {tool.name} has the following urls: {urls}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import pytest
-from mercado.cli import install_tool, get_status
+from mercado.cli import get_status, install_tool
 from mercado.tool_manager import ToolManager
+from mercado.utils import is_valid_os
 
 
 @pytest.mark.parametrize("vendor,tool",
@@ -12,5 +13,8 @@ def test_download_invalid_version(vendor: str, tool: str, os: str, arch: str):
 
 @pytest.mark.parametrize("tool", [t.name for _, tools in ToolManager().get_supported_tools() for t in tools])
 def test_download_and_verify_latest(tool: str, os: str, arch: str):
+    if is_valid_os('darwin', os) and tool in ("docker", "aws", "vagrant"):
+        pytest.xfail("Not supported on Darwin")
+
     install_tool(names=[tool], os=os, arch=arch, dry_run=False)
     get_status(tool)

--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -1,5 +1,6 @@
 import pytest
 from mercado.tool_manager import ToolManager
+from mercado.utils import is_valid_os
 
 
 def test_get_installer_invalid_tool(toolmanager: ToolManager, os: str, arch: str):
@@ -9,5 +10,8 @@ def test_get_installer_invalid_tool(toolmanager: ToolManager, os: str, arch: str
 
 @pytest.mark.parametrize("tool", [t.name for _, tools in ToolManager().get_supported_tools() for t in tools])
 def test_get_installer_happy_flow(toolmanager: ToolManager, tool: str, os: str, arch: str):
+    if is_valid_os('darwin', os) and tool in ("docker", "aws", "vagrant"):
+        pytest.xfail("Not supported on Darwin")
+
     installer = toolmanager.get_installer(tool, os, arch)
     assert toolmanager.get_installer(f"{tool}@{installer.version}", os, arch) == installer


### PR DESCRIPTION
1. Move poetry installation to hack/deps.sh
Have the same dependencies installation logic
both with Docker install and without
(calling directly to 'make deps')

2. Update GHA to run a matrix startegy of macos and ubuntu
- Add tmate support for debugging.
- Explain how to debug in the README.
- Turn `DEBUG` log level on CI.
- Call `make _test` in the GHA job to ignore tests in docker.

3. Move logger configuration initalization to typer callback
There was a bug when multiple tests ran and one of them called
`logging.disable`, the afterwards logs weren't printed.
Hence, `logging.disable` should be called only when used in the
typer context.
Now an external `LOGLEVEL` environment variable is even able
to override this default log level.

4. Support MacOS
skip tests for vagrant, aws, and docker